### PR TITLE
Cw reactions #160

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,5 @@
         }
     ],
     "python.linting.pylintEnabled": true,
-    "python.pythonPath": "/Users/emilyhartzell/.local/share/virtualenvs/rare-api-fakes-news-TNg87HnM/bin/python"
+    "python.pythonPath": "/home/cwelshofer/.local/share/virtualenvs/rare-api-fakes-news-yr2E7QXU/bin/python"
 }

--- a/rareapi.sql
+++ b/rareapi.sql
@@ -1,1 +1,8 @@
-SELECT * FROM rareapi_post
+SELECT * FROM rareapi_postINSERT INTO rareapi_postreaction (id, post_id, reaction_id, user_id)
+VALUES (
+    id:integer,
+    post_id:integer,
+    reaction_id:integer,
+    user_id:integer
+  );
+DELETE  FROM rareapi_postreaction

--- a/rareapi/views/postreaction.py
+++ b/rareapi/views/postreaction.py
@@ -8,6 +8,7 @@ from rareapi.models import PostReaction, Reaction, Post, RareUser
 
 class PostReactions(ViewSet):
     """ Responsible for GET, POST, DELETE """
+
     def list(self, request):
         """ GET all postreaction objects """
         postreactions = PostReaction.objects.all()
@@ -15,8 +16,9 @@ class PostReactions(ViewSet):
         post_id = self.request.query_params.get("postId", None)
         if post_id is not None:
             postreactions = postreactions.filter(post_id=post_id)
-        
-        serializer = PostReactionSerializer(postreactions, many=True, context={'request', request})
+
+        serializer = PostReactionSerializer(
+            postreactions, many=True, context={'request', request})
         return Response(serializer.data)
 
     def create(self, request):
@@ -24,48 +26,47 @@ class PostReactions(ViewSet):
         rareuser = RareUser.objects.get(user=request.auth.user)
         postreaction = PostReaction()
 
-        #these match the properties in PostForm.js
+        # these match the properties in PostForm.js
         post_id = request.data["post_id"]
         reaction_id = request.data["reaction_id"]
 
-        #check if post exists
+        # check if post exists
         try:
             post = Post.objects.get(id=post_id)
-            
+
         except Post.DoesNotExist:
             return Response({'message: invalid post id'}, status=status.HTTP_422_UNPROCESSABLE_ENTITY)
-        
-        #check if reaction exists
+
+        # check if reaction exists
         try:
             reaction = Reaction.objects.get(id=reaction_id)
         except Reaction.DoesNotExist:
             return Response({'message: invalid reaction id'}, status=status.HTTP_422_UNPROCESSABLE_ENTITY)
 
-        #check if postreaction exists
-        try: 
-            postreaction = PostReaction.objects.get(post=post, reaction=reaction)
-            return Response({'message': 'Postreaction already exists for these two items'}, status=status.HTTP_422_UNPROCESSABLE_ENTITY)
-        
+        # check if postreaction exists
 
+        try:
+            postreaction = PostReaction.objects.get(
+                post=post, reaction=reaction, user=rareuser)
+            if postreaction.user.id == rareuser:
+                return Response({'message': 'Postreaction already exists for these two items'}, status=status.HTTP_422_UNPROCESSABLE_ENTITY)
         except PostReaction.DoesNotExist:
-            #if it does not exist, make new obj
-           
+        #     #if it does not exist, make new obj
+            
             postreaction = PostReaction()
             postreaction.post = post
             postreaction.reaction = reaction
             postreaction.user = rareuser
-            
-           
+
             if rareuser is not None:
 
-                try: 
+                try:
                     postreaction.save()
-                    serializer = PostReactionSerializer(postreaction, many=False, )
+                    serializer = PostReactionSerializer(
+                        postreaction, many=False, )
                     return Response(serializer.data, status=status.HTTP_201_CREATED)
                 except ValidationError as ex:
                     return Response({"reason": ex.message}, status=status.HTTP_400_BAD_REQUEST)
-
-        
 
     def destroy(self, request, pk=None):
         """ DELETE """
@@ -78,11 +79,11 @@ class PostReactions(ViewSet):
         except Exception as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
+
 class PostReactionSerializer(serializers.ModelSerializer):
     """ Serializes PostTags """
     class Meta:
         model = PostReaction
         fields = ('id', 'user', 'reaction', 'post')
         depth = 1
-        #so we can access whole reaction and post object
-
+        # so we can access whole reaction and post object

--- a/rareapi/views/postreaction.py
+++ b/rareapi/views/postreaction.py
@@ -31,6 +31,7 @@ class PostReactions(ViewSet):
         #check if post exists
         try:
             post = Post.objects.get(id=post_id)
+            
         except Post.DoesNotExist:
             return Response({'message: invalid post id'}, status=status.HTTP_422_UNPROCESSABLE_ENTITY)
         


### PR DESCRIPTION
#160 refactor reactions provider

## Description
The serverside code to go with my other cw-reactions on clientside to get reaction count to work for different users.

## Tickets
_My PR references these tickets (epic and task tickets)_
#160 refactor reactions provider
​

## How do I access this branch?
can add more than one reaction to a post for a different user.
1. ```git fetch --all```
2. ```git checkout ``` cw-reactions
3. ```python manage.py runserver``` 

​

​
## Types of changes
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing
- [ x] Tested in Postman
- [ x] Tested with Client

<!-- If your postman test was a POST or PUT, copy the object from the body here -->
``` if necessary, postman code here ```
1.Click on post details, see if you can add reactions
2. Logout and log in with different user and see if you can add a second reaction to a post under a different name
3. make sure you can only add one type of reaction per post.
4. repeat with more users if you want.

## Checklist for Reviewer
- [ ] check it out
- [ ] test all edge cases listed and more if you think of them (postman or browser)
- [ ] request changes/approve
- [ ] review code to make sure it fits coding style of project 
<!--
1. alphabetical imports 
2. list, retrieve, create, update, destroy
3. def methods before serializers
4. alphabetize urls
5. (when in doubt, alphabetize)
-->