### PR TITLE
Posts List method refactor

### DIFF
--- a/rareapi/fixtures/users.json
+++ b/rareapi/fixtures/users.json
@@ -10,7 +10,7 @@
             "first_name": "Steve",
             "last_name": "Brownlee",
             "email": "me@me.com",
-            "is_staff": false,
+            "is_staff": true,
             "is_active": true,
             "date_joined": "2020-08-28T14:51:39.989Z",
             "groups": [],

--- a/rareapi/views/post.py
+++ b/rareapi/views/post.py
@@ -17,11 +17,15 @@ class Posts(ViewSet):
     def list(self, request):
 
         posts = Post.objects.all()
-        approvedPosts = []
+        # approved_posts = []
+        print(type(posts))
 
-        for post in posts:
-            if post.approved == True:
-                approvedPosts.append(post)
+        if not request.auth.user.is_staff:
+
+            for post in posts:
+                if post.approved:
+                    # posts.append(post)
+                    posts
 
         for post in posts:
             post.created_by_current_user = None
@@ -40,7 +44,7 @@ class Posts(ViewSet):
             posts = posts.filter(category_id=category_id)
 
         serializer = PostSerializer(
-            approvedPosts, many=True, context={'request': request})
+            posts, many=True, context={'request': request})
         return Response(serializer.data)
 
     def retrieve(self, request, pk=None):

--- a/rareapi/views/post.py
+++ b/rareapi/views/post.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ValidationError
 from django.http import HttpResponseServerError
 from rest_framework import serializers
 from rest_framework import status
+from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 from rareapi.models import Category
@@ -20,7 +21,8 @@ class Posts(ViewSet):
         posts = Post.objects.all()
 
         if not request.auth.user.is_staff:
-            posts = posts.filter(approved = True).exclude(posts.publication_date > date.today())
+            posts = posts.filter(approved = True).filter(publication_date__lt=date.today())
+            
 
         for post in posts:
             post.created_by_current_user = None
@@ -127,6 +129,17 @@ class Posts(ViewSet):
 
         except Exception as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    @action(methods=['patch'], detail=True)
+    def approval(self, request, pk=None):
+
+        post = Post.objects.get(pk=pk)
+
+        post.approved = True
+        post.save()
+        
+        return Response(None, status=status.HTTP_204_NO_CONTENT)
+
 
 
 

--- a/rareapi/views/post.py
+++ b/rareapi/views/post.py
@@ -17,15 +17,9 @@ class Posts(ViewSet):
     def list(self, request):
 
         posts = Post.objects.all()
-        # approved_posts = []
-        print(type(posts))
 
         if not request.auth.user.is_staff:
-
-            for post in posts:
-                if post.approved:
-                    # posts.append(post)
-                    posts
+            posts = posts.filter(approved = True)
 
         for post in posts:
             post.created_by_current_user = None


### PR DESCRIPTION
<!-- Title: short descriptive title that references the feature -->

## Description
<!-- What does this branch add to the project-->
This change refactors the approved posts and future posts conditions of the list method in `views/posts.py`

## Tickets
_My PR references these tickets (epic and task tickets)_

1. #109
​

## How do I access this branch?
<!-- What does this branch add to the project-->
1. ```git fetch --all```
1. ```git checkout TRB-show-approved-posts``` <!-- insert branch name -->
1. ```python manage.py runserver``` 

​

​
## Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing
- [x] Tested in Postman
- [x] Tested with Client

<!-- If your postman test was a POST or PUT, copy the object from the body here -->
``` if necessary, postman code here ```

<!-- testing procedure details might be nice to have -->
with this change in place, going to the home page or doing a Get request to `/posts` should only yield posts that are approved and not in the future.

If you would like a way to see all posts (again) in `users.json` change the `is_staff` property on one of the objects to `true`. Then run `python manage.py loaddata users.json`.

log in to the on the browser as the user you updated and you should see all posts.
​

## Checklist for Reviewer
- [ ] check it out
- [ ] test all edge cases listed and more if you think of them (postman or browser)
- [ ] request changes/approve
- [ ] review code to make sure it fits coding style of project 
<!--
1. alphabetical imports 
2. list, retrieve, create, update, destroy
3. def methods before serializers
4. alphabetize urls
5. (when in doubt, alphabetize)
-->

![bitmoji](https://sdk.bitmoji.com/render/panel/66f90c51-fb53-4d43-a832-3fa3d7846230-6a89f47d-0069-419b-9704-59b7a29d8414-v1.png?transparent=1&palette=1&width=246)